### PR TITLE
Read fPath in the safeFileReader function

### DIFF
--- a/CommandLineApp/ReadTextFileErrorHandling.hs
+++ b/CommandLineApp/ReadTextFileErrorHandling.hs
@@ -1,5 +1,5 @@
 module Main where
-  
+
 import System.IO
 import Control.Exception
 
@@ -10,11 +10,11 @@ catchAny = Control.Exception.catch
 
 safeFileReader :: FilePath -> IO String
 safeFileReader fPath = do
-  entireFileAsString <- catchAny (readFile "temp.txt") $ \error -> do
+  entireFileAsString <- catchAny (readFile fPath) $ \error -> do
     putStrLn $ "Error: " ++ show error
     return ""
   return entireFileAsString
-  
+
 main :: IO ()
 main = do
   fContents <- safeFileReader "temp.txt"


### PR DESCRIPTION
`fPath` was not used in the `safeFileReader` function in `CommandLineApp/ReadTextFileErrorHandling.hs`.